### PR TITLE
fix of deprecated "doctype 5" in jade template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-node_modules/
+node_modules/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-node_modules/*
+node_modules/

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -1,4 +1,4 @@
-doctype 5
+doctype html
 html
   head
     title Backbone App


### PR DESCRIPTION
fix of depracated "doctype 5" in jade template